### PR TITLE
Adding some Bazel remote-cache configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-common --show_timestamps --enable_platform_specific_config --noremote_upload_local_results --disk_cache=.cache
+common --show_timestamps --enable_platform_specific_config --noremote_upload_local_results --disk_cache=.cache --execution_log_compact_file=exec1.log
 # --experimental_convenience_symlinks=ignore
 
 build --cxxopt='-std=c++14'

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-common --show_timestamps --enable_platform_specific_config --noremote_upload_local_results
+common --show_timestamps --enable_platform_specific_config --noremote_upload_local_results --disk_cache=.cache
 # --experimental_convenience_symlinks=ignore
 
 build --cxxopt='-std=c++14'

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
-common --show_timestamps --enable_platform_specific_config --experimental_convenience_symlinks=ignore
+common --show_timestamps --enable_platform_specific_config 
+# --experimental_convenience_symlinks=ignore
 
 build --cxxopt='-std=c++14'
 build --action_env SENTRY_DSN_PATH= --action_env SENTRY_DSN_HOST=

--- a/.bazelrc
+++ b/.bazelrc
@@ -2,3 +2,7 @@ common --show_timestamps --enable_platform_specific_config --experimental_conven
 
 build --cxxopt='-std=c++14'
 build --action_env SENTRY_DSN_PATH= --action_env SENTRY_DSN_HOST=
+
+build:buildkite --experimental_remote_downloader_local_fallback=false
+query:buildkite --experimental_remote_downloader_local_fallback=false
+fetch:buildkite --experimental_remote_downloader_local_fallback=false

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-common --show_timestamps --enable_platform_specific_config 
+common --show_timestamps --enable_platform_specific_config --noremote_upload_local_results
 # --experimental_convenience_symlinks=ignore
 
 build --cxxopt='-std=c++14'
@@ -7,3 +7,7 @@ build --action_env SENTRY_DSN_PATH= --action_env SENTRY_DSN_HOST=
 build:buildkite --experimental_remote_downloader_local_fallback=false
 query:buildkite --experimental_remote_downloader_local_fallback=false
 fetch:buildkite --experimental_remote_downloader_local_fallback=false
+
+common:upload --disk_cache=
+common:upload --remote_upload_local_results
+common:buildkite --config=upload

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,6 +43,9 @@ steps:
           bazel-config: "buildkite"
           output-filename: ".bazelrc-generated"
           path: "pipelines/flappykite/bazel"
+    artifact_paths:
+      - "./bazel-bin/FlappyKite/FlappyKite.ipa"
+      - "exec1.log"
 
   # - label: ":bazel: test"
   #   key: bazel-test

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,7 +38,7 @@ steps:
     #   name: "bazel"
     plugins:
       - aws-assume-role-with-web-identity#v1.1.0:
-          role-arn: "arn:aws:iam::724772075326:role/oidc-flappykite-secretsmanager"
+          role-arn: "$ROLE_ARN"
       - aws-secretsmanager-to-bazelrc#main:
           bazel-config: "buildkite"
           output-filename: ".bazelrc-generated"
@@ -58,7 +58,7 @@ steps:
     #   name: "bazel"
     plugins:
       - aws-assume-role-with-web-identity#v1.1.0:
-          role-arn: "arn:aws:iam::724772075326:role/oidc-flappykite-secretsmanager"
+          role-arn: "$ROLE_ARN"
       - aws-secretsmanager-to-bazelrc#main:
           bazel-config: "buildkite"
           output-filename: ".bazelrc-generated"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,20 +28,38 @@ steps:
 
   - label: ":bazel: build"
     key: bazel-build
-    command: "bazelisk build //FlappyKite:FlappyKite"
+    command: "bazelisk --bazelrc=.bazelrc --bazelrc=.bazelrc-generated build --config=buildkite //FlappyKite:FlappyKite"
+    env:
+      AWS_REGION: us-east-1
     cache:
       paths:
         - ".cache"
       size: "20g"
       name: "bazel"
+    plugins:
+      - aws-assume-role-with-web-identity#v1.1.0:
+          role-arn: "arn:aws:iam::724772075326:role/oidc-flappykite-secretsmanager"
+      - aws-secretsmanager-to-bazelrc#main:
+          bazel-config: "buildkite"
+          output-filename: ".bazelrc-generated"
+          path: "pipelines/flappykite/bazel"
 
   - label: ":bazel: test"
     key: bazel-test
     depends_on:
       - bazel-build
-    command: "bazelisk build //FlappyKiteTests:FlappyKiteTests //FlappyKiteUITests:FlappyKiteUITests"
+    command: "bazelisk --bazelrc=.bazelrc --bazelrc=.bazelrc-generated test --config=buildkite //FlappyKiteTests:FlappyKiteTests //FlappyKiteUITests:FlappyKiteUITests"
+    env:
+      AWS_REGION: us-east-1
     cache:
       paths:
         - ".cache"
       size: "20g"
       name: "bazel"
+    plugins:
+      - aws-assume-role-with-web-identity#v1.1.0:
+          role-arn: "arn:aws:iam::724772075326:role/oidc-flappykite-secretsmanager"
+      - aws-secretsmanager-to-bazelrc#main:
+          bazel-config: "buildkite"
+          output-filename: ".bazelrc-generated"
+          path: "pipelines/flappykite/bazel"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,3 +63,6 @@ steps:
           bazel-config: "buildkite"
           output-filename: ".bazelrc-generated"
           path: "pipelines/flappykite/bazel"
+    artifact_paths:
+      - "./bazel-out/darwin_arm64-fastbuild/testlogs/FlappyKiteUITests/FlappyKiteUITests/test.log"
+      - "./bazel-out/darwin_arm64-fastbuild/testlogs/FlappyKiteTests/FlappyKiteTests/test.log"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,25 +44,25 @@ steps:
           output-filename: ".bazelrc-generated"
           path: "pipelines/flappykite/bazel"
 
-  - label: ":bazel: test"
-    key: bazel-test
-    depends_on:
-      - bazel-build
-    command: "bazelisk --bazelrc=.bazelrc --bazelrc=.bazelrc-generated test --config=buildkite //FlappyKiteTests:FlappyKiteTests //FlappyKiteUITests:FlappyKiteUITests"
-    env:
-      AWS_REGION: us-east-1
-    # cache:
-    #   paths:
-    #     - ".cache"
-    #   size: "20g"
-    #   name: "bazel"
-    plugins:
-      - aws-assume-role-with-web-identity#v1.1.0:
-          role-arn: "$ROLE_ARN"
-      - aws-secretsmanager-to-bazelrc#main:
-          bazel-config: "buildkite"
-          output-filename: ".bazelrc-generated"
-          path: "pipelines/flappykite/bazel"
-    artifact_paths:
-      - "./bazel-out/darwin_arm64-fastbuild/testlogs/FlappyKiteUITests/FlappyKiteUITests/test.log"
-      - "./bazel-out/darwin_arm64-fastbuild/testlogs/FlappyKiteTests/FlappyKiteTests/test.log"
+  # - label: ":bazel: test"
+  #   key: bazel-test
+  #   depends_on:
+  #     - bazel-build
+  #   command: "bazelisk --bazelrc=.bazelrc --bazelrc=.bazelrc-generated test --config=buildkite //FlappyKiteTests:FlappyKiteTests //FlappyKiteUITests:FlappyKiteUITests"
+  #   env:
+  #     AWS_REGION: us-east-1
+  #   # cache:
+  #   #   paths:
+  #   #     - ".cache"
+  #   #   size: "20g"
+  #   #   name: "bazel"
+  #   plugins:
+  #     - aws-assume-role-with-web-identity#v1.1.0:
+  #         role-arn: "$ROLE_ARN"
+  #     - aws-secretsmanager-to-bazelrc#main:
+  #         bazel-config: "buildkite"
+  #         output-filename: ".bazelrc-generated"
+  #         path: "pipelines/flappykite/bazel"
+  #   artifact_paths:
+  #     - "./bazel-out/darwin_arm64-fastbuild/testlogs/FlappyKiteUITests/FlappyKiteUITests/test.log"
+  #     - "./bazel-out/darwin_arm64-fastbuild/testlogs/FlappyKiteTests/FlappyKiteTests/test.log"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,11 +31,11 @@ steps:
     command: "bazelisk --bazelrc=.bazelrc --bazelrc=.bazelrc-generated build --config=buildkite //FlappyKite:FlappyKite"
     env:
       AWS_REGION: us-east-1
-    cache:
-      paths:
-        - ".cache"
-      size: "20g"
-      name: "bazel"
+    # cache:
+    #   paths:
+    #     - ".cache"
+    #   size: "20g"
+    #   name: "bazel"
     plugins:
       - aws-assume-role-with-web-identity#v1.1.0:
           role-arn: "arn:aws:iam::724772075326:role/oidc-flappykite-secretsmanager"
@@ -51,11 +51,11 @@ steps:
     command: "bazelisk --bazelrc=.bazelrc --bazelrc=.bazelrc-generated test --config=buildkite //FlappyKiteTests:FlappyKiteTests //FlappyKiteUITests:FlappyKiteUITests"
     env:
       AWS_REGION: us-east-1
-    cache:
-      paths:
-        - ".cache"
-      size: "20g"
-      name: "bazel"
+    # cache:
+    #   paths:
+    #     - ".cache"
+    #   size: "20g"
+    #   name: "bazel"
     plugins:
       - aws-assume-role-with-web-identity#v1.1.0:
           role-arn: "arn:aws:iam::724772075326:role/oidc-flappykite-secretsmanager"

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ fastlane/test_output/report.junit
 # Bazel related paths
 bazel-*
 .build
+log
+.cache
+*.log


### PR DESCRIPTION
Armed with a very fresh plugin, and some infra running in AWS, give FlappyKite a remote Bazel cache to use.